### PR TITLE
fix: zustand를 통한 유저 정보 전역 상태 관리

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.4.1",
     "sockjs-client": "^1.6.1",
-    "swiper": "^11.2.6"
+    "swiper": "^11.2.6",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",

--- a/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
+++ b/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
@@ -19,6 +19,7 @@ import Button from '@components/chatRoomCreated/LoginButton';
 import axios from 'axios';
 import { useNavigate, useParams } from 'react-router-dom';
 import { joinRoom } from '@api/login';
+import useRoomUsersStore from '@store/useRoomUsersStore';
 
 const UserEnterChatRoom = () => {
   const { nickname, isNicknameValid, handleNicknameChange } = useNicknameValidation();
@@ -27,12 +28,21 @@ const UserEnterChatRoom = () => {
 
   const { roomKey } = useParams();
   const navigate = useNavigate();
+  const addUser = useRoomUsersStore((state) => state.addUser);
+  const resetUsers = useRoomUsersStore((state) => state.resetUsers);
 
   const handleJoin = async () => {
     if (!roomKey) return;
     try {
       const res = await joinRoom(roomKey, { nickname, password });
       console.log(res);
+      if (res.data.data.isLeader) {
+        resetUsers();
+      }
+      addUser(res.data.data);
+      const updatedUsers = useRoomUsersStore.getState().users;
+      console.log('전역 저장된 users:', updatedUsers);
+
       navigate(`/rooms/${roomKey}/chat`);
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {

--- a/src/store/useRoomUsersStore.ts
+++ b/src/store/useRoomUsersStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface UserInfo {
+  nickname: string;
+  character: string;
+  isLeader: boolean;
+}
+
+interface RoomUsersState {
+  users: UserInfo[];
+  addUser: (user: UserInfo) => void;
+  removeUser: (nickname: string) => void;
+  resetUsers: () => void;
+}
+
+const useRoomUsersStore = create<RoomUsersState>()(
+  persist(
+    (set) => ({
+      users: [],
+      addUser: (user) =>
+        set((state) => {
+          const alreadyExists = state.users.some((u) => u.nickname === user.nickname);
+          if (alreadyExists) return state;
+          return { users: [...state.users, user] };
+        }),
+      removeUser: (nickname) =>
+        set((state) => ({
+          users: state.users.filter((u) => u.nickname !== nickname),
+        })),
+      resetUsers: () => {
+        set({ users: [] });
+        localStorage.removeItem('room-users');
+      },
+    }),
+    {
+      name: 'room-users',
+    },
+  ),
+);
+
+export default useRoomUsersStore;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
       "@layout/*": ["src/layout/*"],
       "@pages/*": ["src/pages/*"],
       "@assets/*": ["src/assets/*"],
-      "@hooks/*": ["src/hooks/*"]
+      "@hooks/*": ["src/hooks/*"],
+      "@store/*": ["src/store/*"]
     }
   },
   "include": ["src", "swiper-css.d.ts"], // 타입 검사 포함 디렉토리

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       '@assets': path.resolve(__dirname, 'src/assets'),
       '@hooks': path.resolve(__dirname, './src/hooks'),
       '@styles': path.resolve(__dirname, './src/styles'),
+      '@store': path.resolve(__dirname, './src/store'),
     },
   },
   server: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,3 +2824,8 @@ yocto-queue@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+
+zustand@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.4.tgz#33af161f1e337854ccd8b711ef9e92545d6ae53f"
+  integrity sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==


### PR DESCRIPTION
## PR 제목

### 이슈 번호 📎

- #18 

### 변경사항 🛠

- zustand 설치
- zustand persist를 통해 localStrage에 유저 정보(nickname, charaterId, isLeader)저장
- 새로운 방 입장 시 이전 유저 정보 초기화 및 저장된 localstorage 삭제

### 특이사항 📌

- (이 PR에 대한 추가적인 정보나, 리뷰어가 주의깊게 봐야할 점 등을 적어주세요.)
