### PR TITLE
FIx: 리다이렉션 처리, 오타 수정

### DIFF
--- a/src/components/Main/KeyWordMode.tsx
+++ b/src/components/Main/KeyWordMode.tsx
@@ -77,7 +77,7 @@ export default KeywordModeBox;
 // 스타일 컴포넌트
 const KeyWordBox = styled(Container)`
   width: 287px;
-  height: 343px;
+  min-height: 343px;
   gap: 15px;
   border-radius: 18px;
   border: 1px solid #e4e4e4;
@@ -104,6 +104,7 @@ const KeyWordSubTitle = styled(SubTitle)`
 const Selector = styled(Container)`
   margin-top: 9px;
   gap: 17px;
+  min-height: 90px;
 `;
 
 const Complete = styled(Button)`

--- a/src/components/chatRoom/InviteModal.tsx
+++ b/src/components/chatRoom/InviteModal.tsx
@@ -10,7 +10,7 @@ interface SummaryModalProps {
   roomId: string;
 }
 const InviteModal = ({ onClose, roomId }: SummaryModalProps) => {
-  const chatRoomUrl = `https://oki/rooms/${roomId}/member`;
+  const chatRoomUrl = `https://dev.okii.kr/rooms/${roomId}/member`;
   const [qrValue, setQrValue] = useState(chatRoomUrl);
   const [downloaded, setDownloaded] = useState(false);
   const [copy, setCopy] = useState(false);
@@ -102,10 +102,8 @@ const QRText = styled.p`
   margin-top: 10px;
   color: #3e3333;
   text-align: center;
-
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 500;
-
   cursor: pointer;
 `;
 const QRSubText = styled.p`

--- a/src/components/chatRoom/messageModal.tsx
+++ b/src/components/chatRoom/messageModal.tsx
@@ -18,7 +18,7 @@ const messages = {
   },
 };
 interface MessageModalProps {
-  onClose: () => void;
+  onClose?: () => void;
   kind: 'warning' | 'closed' | 'ended';
   roomkey?: string;
 }
@@ -36,7 +36,7 @@ const MessageModal = ({ onClose, kind, roomkey }: MessageModalProps) => {
 
   return (
     <>
-      <Mask onClick={onClose} />
+      <Mask onClick={kind === 'warning' ? onClose : undefined} />
       <MessageModalBody>
         <Title>{messages[kind].title}</Title>
         <SubTitle>{messages[kind].subTitle}</SubTitle>

--- a/src/components/chatRoom/messageModal.tsx
+++ b/src/components/chatRoom/messageModal.tsx
@@ -27,12 +27,12 @@ const MessageModal = ({ onClose, kind, roomkey }: MessageModalProps) => {
   useEffect(() => {
     if (kind === 'ended' || kind === 'closed') {
       const timeout = setTimeout(() => {
-        navigate('/rooms/exit', { state: roomkey }); // 모달이 뜬 후 5초 후 이동
+        navigate('/rooms/exit', { state: { roomKey: roomkey } }); // 모달이 뜬 후 5초 후 이동
       }, 5000); // 5초 후에 이동
 
       return () => clearTimeout(timeout); // 컴포넌트 언마운트 시 타이머 클리어
     }
-  }, [kind, navigate]);
+  }, [kind, navigate, roomkey]);
 
   return (
     <>

--- a/src/components/chatRoomExit/Button.tsx
+++ b/src/components/chatRoomExit/Button.tsx
@@ -10,7 +10,7 @@ const Button = ({ text, onClick }: { text: string; onClick: () => void }) => {
 export default Button;
 const NaviButton = styled.button`
   width: 253px;
-  height: 57px;
+  min-height: 57px;
   background-color: #ff7913;
   color: white;
   border-radius: 15px;
@@ -18,6 +18,5 @@ const NaviButton = styled.button`
   font-weight: 600;
   cursor: pointer;
   align-self: center;
-  position: absolute;
-  bottom: 47px;
+  margin-bottom: 30px;
 `;

--- a/src/components/shared/UIStyles.ts
+++ b/src/components/shared/UIStyles.ts
@@ -4,7 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100dvh;
+  min-height: 100dvh;
 `;
 export const Header = styled.div`
   display: flex;

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -120,14 +120,14 @@ const MainPage = () => {
         <ChevronRight $isRightActive={activeMode === 1} onClick={() => setActiveMode(1)} />
       </ModeContainer>
 
-      <Footer>버전 정보</Footer>
+      <Footer>버전 정보 v1.0.0</Footer>
     </MainContainer>
   );
 };
 export default MainPage;
 
 const MainContainer = styled(Container)`
-  margin-top: 6dvh;
+  padding-top: 6dvh;
 `;
 
 const MainHeader = styled(Header)`
@@ -136,6 +136,7 @@ const MainHeader = styled(Header)`
 `;
 const ModeContainer = styled(Container)`
   flex-direction: row;
+  min-height: 343px;
 `;
 
 const IconStyle = styled.div<{ $visible: boolean }>`

--- a/src/pages/chatRoom/ChatRoomPage.tsx
+++ b/src/pages/chatRoom/ChatRoomPage.tsx
@@ -181,7 +181,7 @@ const ChatRoomPage = () => {
         setRoomData(res.data);
       } catch (error) {
         console.error('Error fetching room data:', error);
-        navigate('/');
+        navigate('/rooms/exit');
       }
     };
     fetchRoomData();

--- a/src/pages/chatRoom/ChatRoomPage.tsx
+++ b/src/pages/chatRoom/ChatRoomPage.tsx
@@ -142,7 +142,9 @@ const ChatRoomPage = () => {
       onDisconnect: () => {
         console.log('웹소켓 연결 해제');
         setConnected(false);
-        navigate('/rooms/exit', { state: { roomKey } });
+        if (user?.isLeader) {
+          navigate('/rooms/exit', { state: { roomKey } });
+        }
       },
       onStompError: (frame) => {
         console.error('STOMP 에러:', frame);

--- a/src/pages/chatRoom/ChatRoomPage.tsx
+++ b/src/pages/chatRoom/ChatRoomPage.tsx
@@ -224,11 +224,12 @@ const ChatRoomPage = () => {
           <MessageModal onClose={() => setIsEndedOpen(false)} kind='ended' roomkey={roomKey} />
         </ModalPortal>
       )}
-      {isClosedOpen && (
+      {isClosedOpen && !user?.isLeader && (
         <ModalPortal>
           <MessageModal onClose={() => setIsClosedOpen(false)} kind='closed' roomkey={roomKey} />
         </ModalPortal>
       )}
+
       {isWarningOpen && (
         <ModalPortal>
           <MessageModal onClose={() => setIsWarningOpen(false)} kind='warning' />

--- a/src/pages/chatRoom/ChatRoomPage.tsx
+++ b/src/pages/chatRoom/ChatRoomPage.tsx
@@ -109,11 +109,16 @@ const ChatRoomPage = () => {
                 setKeyword([]);
               }
             } else if (data.type === 'ROOM_EXPIRED') {
-              console.log('방 만료됨');
-              setIsEndedOpen(true);
+              if (data.type === 'LEADER_ROOM_EXPIRED') {
+                console.log('방 만료됨');
+                setIsEndedOpen(true);
+              }
             } else if (data.type === 'ROOM_EXPIRY_WARNING') {
               console.log('방 종료 5분 남음');
               setIsWarningOpen(true);
+            } else if (data.type === 'LEADER_ROOM_EXPIRED') {
+              console.log('방장이 방 종료');
+              setIsClosedOpen(true);
             }
           } catch (e) {
             console.error('메시지 파싱 오류:', e);

--- a/src/pages/chatRoomExit/chatRoomExitPage.tsx
+++ b/src/pages/chatRoomExit/chatRoomExitPage.tsx
@@ -19,7 +19,8 @@ const ChatRoomExitPage = () => {
     }
   }, [roomKey, isExpired]);
 
-  if (isExpired || roomResult === null) return <ChatRoomExpiredPage />;
+  if (isExpired || !roomKey || roomResult === null) return <ChatRoomExpiredPage />;
+
   if (roomResult === undefined) return null;
   return <ChatRoomSummaryPage roomResult={roomResult} />;
 };

--- a/src/pages/chatRoomExit/chatRoomExpiredPage.tsx
+++ b/src/pages/chatRoomExit/chatRoomExpiredPage.tsx
@@ -9,20 +9,30 @@ import { useNavigate } from 'react-router-dom';
 const ChatRoomExpiredPage = () => {
   const navigate = useNavigate();
   return (
-    <Container>
-      <ProfileImage src={errorIcon} />
-      <Header>
-        <Title>채팅룸이 종료되었어요.</Title>
-        <SubTitle>이미 종료된 채팅룸이에요. 새 방을 만들어 볼까요?</SubTitle>
-      </Header>
+    <ExpiryContainer>
+      <Box>
+        <ProfileImage src={errorIcon} />
+        <Header>
+          <Title>채팅룸이 종료되었어요.</Title>
+          <SubTitle>이미 종료된 채팅룸이에요. 새 방을 만들어 볼까요?</SubTitle>
+        </Header>
+      </Box>
       <Button text='새로운 채팅룸 만들기' onClick={() => navigate('/rooms')} />
-    </Container>
+    </ExpiryContainer>
   );
 };
 export default ChatRoomExpiredPage;
 
 const ProfileImage = styled.img`
-  margin-top: 216px;
+  margin-top: 150px;
   margin-bottom: 23px;
-  align-self: center;
+  justify-self: center;
+`;
+const ExpiryContainer = styled(Container)`
+  justify-content: space-between;
+`;
+const Box = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;

--- a/src/pages/chatRoomExit/chatRoomSummaryPage.tsx
+++ b/src/pages/chatRoomExit/chatRoomSummaryPage.tsx
@@ -88,7 +88,14 @@ const ChatRoomSummaryPage = ({ roomResult }: { roomResult: RoomResult }) => {
       </StatsContainer>
       <FeedbackBox>
         <FeedbackText>서비스 피드백을 부탁드려도 될까요?</FeedbackText>
-        <FormLinkText>https://docs.google.com/forms/435432</FormLinkText>
+        <FormLinkText
+          as='a'
+          href='https://forms.gle/pw8awcwaZ3vmvETA9'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          https://forms.gle/pw8awcwaZ3vmvETA9
+        </FormLinkText>
       </FeedbackBox>
       <Button text='메인으로 돌아가기' onClick={() => navigate('/rooms')} />
       {isOpen && roomResult && (
@@ -104,7 +111,7 @@ const ResultText = styled(Title)`
   font-size: 19px;
 `;
 const SummaryHeader = styled(Header)`
-  margin-top: 20px;
+  margin-top: 30px;
 `;
 const StatsContainer = styled.div`
   width: 342px;
@@ -120,7 +127,7 @@ const FeedbackText = styled.p`
   color: #7c7c7c;
   text-align: center;
 `;
-const FormLinkText = styled.p`
+const FormLinkText = styled.a`
   font-size: 14px;
   font-weight: 400;
   color: #7c7c7c;

--- a/src/pages/chatRoomExit/chatRoomSummaryPage.tsx
+++ b/src/pages/chatRoomExit/chatRoomSummaryPage.tsx
@@ -34,7 +34,7 @@ const ChatRoomSummaryPage = ({ roomResult }: { roomResult: RoomResult }) => {
   return (
     <Container>
       <SummaryHeader>
-        <Title>채팅룸이 종료되었습니다!</Title>
+        <ResultText>채팅룸이 종료되었습니다!</ResultText>
         <SubTitle>대화는 즐거우셨나요? 요약 결과를 보여드릴게요.</SubTitle>
       </SummaryHeader>
       <StatsContainer>
@@ -45,36 +45,36 @@ const ChatRoomSummaryPage = ({ roomResult }: { roomResult: RoomResult }) => {
               <Divider />
               <TagWrapper>
                 {roomResult.sharedKeywords.map((keyword, id) => (
-                  <Title key={id}>#{keyword}</Title>
+                  <ResultText key={id}>#{keyword}</ResultText>
                 ))}
               </TagWrapper>
             </Wrapper>
             <Wrapper>
               <MainText>총 대화 시간</MainText>
               <Divider />
-              <Title>{roomResult.totalDuration}</Title>
+              <ResultText>{roomResult.totalDuration}</ResultText>
             </Wrapper>
             <Wrapper>
               <MainText>가장 많은 키워드를 작성한 사람</MainText>
               <Divider />
-              <Title>
+              <ResultText>
                 1위:{' '}
                 {roomResult.topKeywordContributorNames.length > 1
                   ? roomResult.topKeywordContributorNames.join(', ')
                   : roomResult.topKeywordContributorNames[0]}{' '}
                 ({roomResult.topKeywordCount}개)
-              </Title>
+              </ResultText>
             </Wrapper>
             <Wrapper>
               <MainText>취미가 가장 많이 겹친 사람</MainText>
               <Divider />
-              <Title>
+              <ResultText>
                 1위:{' '}
                 {roomResult.mostMatchedHobbyUserNames.length > 1
                   ? roomResult.mostMatchedHobbyUserNames.join(', ')
                   : roomResult.mostMatchedHobbyUserNames[0]}{' '}
                 ({roomResult.matchedHobbyCount}개)
-              </Title>
+              </ResultText>
             </Wrapper>
           </Box>
         ) : (
@@ -100,8 +100,11 @@ const ChatRoomSummaryPage = ({ roomResult }: { roomResult: RoomResult }) => {
   );
 };
 export default ChatRoomSummaryPage;
+const ResultText = styled(Title)`
+  font-size: 19px;
+`;
 const SummaryHeader = styled(Header)`
-  margin-top: 40px;
+  margin-top: 20px;
 `;
 const StatsContainer = styled.div`
   width: 342px;
@@ -124,27 +127,27 @@ const FormLinkText = styled.p`
   text-align: center;
 `;
 const MainText = styled.p`
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 500;
 `;
 const Box = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 30px;
+  justify-content: space-between;
   width: 342px;
   min-height: 376px;
   flex-shrink: 0;
   border-radius: 12px;
   border: 1px solid #e4e4e4;
   box-sizing: border-box;
-  padding: 27px 0;
+  padding: 33px 0;
   margin-top: 25px;
 `;
 const Wrapper = styled.div`
   display: flex;
   width: 299px;
-  min-height: 61px;
+  min-height: 55px;
   flex-direction: column;
   align-items: flex-start;
 `;
@@ -152,7 +155,7 @@ const Divider = styled.div`
   width: 299px;
   height: 1px;
   background-color: #f0f0f0;
-  margin: 9px 0;
+  margin: 6px 0;
 `;
 const TagWrapper = styled.div`
   display: flex;
@@ -189,7 +192,8 @@ const FeedbackBox = styled.div`
   align-self: center;
   padding: 20px 0;
   box-sizing: border-box;
-  margin: 20px 0;
+  margin-top: 20px;
+  margin-bottom: 40px;
 `;
 const Download = styled(DownloadIcon)`
   width: 20px;

--- a/src/pages/onBoarding/onBoardingPage.tsx
+++ b/src/pages/onBoarding/onBoardingPage.tsx
@@ -27,8 +27,8 @@ const OnBoardingPage = () => {
 export default OnBoardingPage;
 
 const OnBoardingContainer = styled(Container)`
-  margin-top: 10dvh;
-  gap: 94px;
+  padding-top: 8dvh;
+  justify-content: space-between;
 `;
 const OnBoardingHeader = styled(Header)`
   gap: 10px;
@@ -51,5 +51,5 @@ const MainContainer = styled.div`
   }
 `;
 const IconGroup = styled(Icons)`
-  position: absolute;
+  //position: absolute;
 `;

--- a/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
+++ b/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
@@ -74,56 +74,58 @@ const UserEnterChatRoom = () => {
 
   return (
     <UserEnterContainer>
-      <UserEnterHeader>
-        <TitleText>키워드를 입력하러 가 볼까요?</TitleText>
-        <SubTitleText>사용할 닉네임과 비밀번호를 입력해주세요</SubTitleText>
-      </UserEnterHeader>
-      <LoginContainer>
-        <LoginForm>
-          <InputContainer>
-            <InputLabel>
-              닉네임
-              <NicknameInput
-                type='text'
-                name='nickname'
-                value={nickname}
-                $valid={isNicknameValid}
-                onChange={(e) => handleNicknameChange(e.target.value)}
-                placeholder='채팅방에서 사용할 닉네임을 입력해주세요.'
-                autoComplete='on'
-                required
-              />
-              <CircleIcon $valid={isNicknameValid} />
-              <CheckIcon $show={isNicknameValid === true} />
-              <XMarkIcon $show={isNicknameValid === false} />
-            </InputLabel>
-            <ValidationMessage valid={isNicknameValid} type='nickname' />
-          </InputContainer>
+      <div>
+        <UserEnterHeader>
+          <TitleText>키워드를 입력하러 가 볼까요?</TitleText>
+          <SubTitleText>사용할 닉네임과 비밀번호를 입력해주세요</SubTitleText>
+        </UserEnterHeader>
+        <LoginContainer>
+          <LoginForm>
+            <InputContainer>
+              <InputLabel>
+                닉네임
+                <NicknameInput
+                  type='text'
+                  name='nickname'
+                  value={nickname}
+                  $valid={isNicknameValid}
+                  onChange={(e) => handleNicknameChange(e.target.value)}
+                  placeholder='채팅방에서 사용할 닉네임을 입력해주세요.'
+                  autoComplete='on'
+                  required
+                />
+                <CircleIcon $valid={isNicknameValid} />
+                <CheckIcon $show={isNicknameValid === true} />
+                <XMarkIcon $show={isNicknameValid === false} />
+              </InputLabel>
+              <ValidationMessage valid={isNicknameValid} type='nickname' />
+            </InputContainer>
 
-          <InputContainer>
-            <InputLabel>
-              비밀번호
-              <PasswordInput
-                type='password'
-                name='password'
-                value={password}
-                $valid={isPasswordValid}
-                onChange={(e) => handlePasswordChange(e.target.value)}
-                placeholder='채팅방에서 사용할 비밀번호를 입력해 주세요.'
-                autoComplete='current-password'
-                required
-              />
-              <CircleIcon $valid={isPasswordValid} />
-              <CheckIcon $show={isPasswordValid === true} />
-              <XMarkIcon $show={isPasswordValid === false} />
-            </InputLabel>
-            <ValidationMessage valid={isPasswordValid} type='password' />
-          </InputContainer>
-        </LoginForm>
-      </LoginContainer>
+            <InputContainer>
+              <InputLabel>
+                비밀번호
+                <PasswordInput
+                  type='password'
+                  name='password'
+                  value={password}
+                  $valid={isPasswordValid}
+                  onChange={(e) => handlePasswordChange(e.target.value)}
+                  placeholder='채팅방에서 사용할 비밀번호를 입력해 주세요.'
+                  autoComplete='current-password'
+                  required
+                />
+                <CircleIcon $valid={isPasswordValid} />
+                <CheckIcon $show={isPasswordValid === true} />
+                <XMarkIcon $show={isPasswordValid === false} />
+              </InputLabel>
+              <ValidationMessage valid={isPasswordValid} type='password' />
+            </InputContainer>
+          </LoginForm>
+        </LoginContainer>
+      </div>
       <ButtonContainer>
         <ButtonText>*닉네임과 비밀번호는 이번 채팅방에서만 사용돼요.</ButtonText>
-        <EntranceButton onClick={handleJoin} text='키워드 입력하러 가기' active={isFormValid} />
+        <Button onClick={handleJoin} text='키워드 입력하러 가기' active={isFormValid} />
       </ButtonContainer>
     </UserEnterContainer>
   );
@@ -132,10 +134,14 @@ const UserEnterChatRoom = () => {
 export default UserEnterChatRoom;
 
 const UserEnterContainer = styled(Container)`
-  margin-top: 97px;
-  gap: 59px;
+  padding-top: 80px;
+  justify-content: space-between;
+  box-sizing: border-box;
+  padding-bottom: 24px;
 `;
-const UserEnterHeader = styled(Header)``;
+const UserEnterHeader = styled(Header)`
+  margin-bottom: 55px;
+`;
 const TitleText = styled(Title)`
   color: #3e3333;
   text-align: center;
@@ -145,16 +151,12 @@ const SubTitleText = styled(SubTitle)`
 `;
 
 const ButtonContainer = styled(Container)`
-  margin-top: 244px;
   gap: 13px;
+  min-height: 50px;
 `;
 const ButtonText = styled.p`
   color: #b7b7b7;
   font-size: 10px;
   font-weight: 500;
   text-align: center;
-`;
-const EntranceButton = styled(Button)`
-  position: absolute;
-  bottom: 47px;
 `;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -15,6 +15,7 @@ const GlobalStyles = () => (
         font-family: 'Pretendard Variable', sans-serif;
         margin: 0;
         padding: 0;
+        -webkit-tap-highlight-color: transparent;
       }
       body {
         color: black;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -16,6 +16,9 @@ const GlobalStyles = () => (
         margin: 0;
         padding: 0;
         -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        -webkit-touch-callout: none;
+        user-select: none;
       }
       body {
         color: black;
@@ -33,6 +36,11 @@ const GlobalStyles = () => (
       }
       button {
         border: none;
+      }
+      input,
+      textarea {
+        -webkit-user-select: text;
+        user-select: text;
       }
     `}
   />


### PR DESCRIPTION
### 변경사항 🛠

- 방장이 채팅 종료하면 종료 모달 뜨지 않도록 수정
- 방장이 아닌 유저가 채팅방을 나가면 메인화면으로 이동하도록 수정(원래는 메인화면으로 이동했다가 바로 /rooms/exit 화면으로 이동됐음)
- roomKey 오타를 수정해서 채팅방 요약 정보를 불러올 수 있도록 수정
- 만료된 채팅방에 다시 로그인 성공시, 만료 페이지로 리다이렉션 처리
- 방장이 방을 종료했다는 모달이 나오도록 수정

- 채팅방 공유 링크, 구글폼 링크 반영
- 텍스트 선택 처리 방지
- 버튼 및 스타일 수정

