### PR TITLE
Feat: 투표 결과 페이지 api 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,10 +36,7 @@ function App() {
             <Route path='/tmi/:roomKey/input' element={<TMIInputPage />} />
             <Route path='/tmi/:roomKey/load' element={<TMILoadPage />} />
             <Route path='/tmi/:roomKey/hint' element={<TMIHintPage />} />
-          </Route>
-
-          <Route>
-            <Route path='/voteResult' element={<VoteResult />} />
+            <Route path='/tmi/:roomKey/voteResult' element={<VoteResult />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/api/voteResult.ts
+++ b/src/api/voteResult.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+interface VotingResultsResponse {
+  tmiContent: string;
+  correctAnswer: string;
+  myVote: string;
+  isCorrect: boolean;
+  votingResults: Record<string, number>;
+  round: number;
+}
+
+export const getTmiVoteResult = async (roomKey: string) => {
+  const response = await axios.get<{ data: VotingResultsResponse }>(
+    `/api/tmi/rooms/${roomKey}/votes/result`,
+  );
+  console.log(response.data);
+  return response.data.data;
+};

--- a/src/components/shared/CharacterMap.ts
+++ b/src/components/shared/CharacterMap.ts
@@ -1,0 +1,19 @@
+import rabbit from '@assets/chatRoom/character/rabbit.svg';
+import bear from '@assets/chatRoom/character/bear.svg';
+import cat from '@assets/chatRoom/character/cat.svg';
+import chick from '@assets/chatRoom/character/chick.svg';
+import pan from '@assets/chatRoom/character/pan.svg';
+import pig from '@assets/chatRoom/character/pig.svg';
+import snake from '@assets/chatRoom/character/snake.svg';
+
+export const CharacterMap = {
+  RABBIT: rabbit,
+  BEAR: bear,
+  FOX: cat,
+  CHICK: chick,
+  PANDA: pan,
+  PIG: pig,
+  TURTLE: snake,
+} as const;
+
+export type CharacterKey = keyof typeof CharacterMap;

--- a/src/components/voteResult/SummaryModal.tsx
+++ b/src/components/voteResult/SummaryModal.tsx
@@ -2,24 +2,26 @@ import styled from '@emotion/styled';
 import { Mask, ModalBody } from '@components/shared/ModalStyles';
 import { SubTitle } from '@components/shared/TextStyles';
 import { Header } from '@components/shared/UIStyles';
+import { CharacterMap, CharacterKey } from '@components/shared/CharacterMap';
 
 interface SummaryModalProps {
   onClose: () => void;
+  correctAnswer: string;
+  tmiContent: string;
+  character: string;
 }
 
-const SummaryModal = ({ onClose }: SummaryModalProps) => {
+const SummaryModal = ({ onClose, correctAnswer, tmiContent, character }: SummaryModalProps) => {
+  const charKey = character.toUpperCase() as CharacterKey;
+  const characterImg = CharacterMap[charKey];
   return (
     <Mask onClick={onClose}>
       <ModalBoddy>
-        <ModalTitle>정답은 두리 님이었습니다.</ModalTitle>
+        <ModalTitle>정답은 {correctAnswer} 님이었습니다.</ModalTitle>
         <MainContainer>
-          <CharacterImg />
+          <CharacterImg src={characterImg} />
           <Divider />
-          <TmiText>
-            “오늘 아침에 양치하다가 칫솔을
-            <br />
-            떨어뜨려서 새 칫솔로 교체했어요.”
-          </TmiText>
+          <TmiText>{tmiContent}</TmiText>
         </MainContainer>
       </ModalBoddy>
     </Mask>

--- a/src/pages/tmiVote/votingPage.tsx
+++ b/src/pages/tmiVote/votingPage.tsx
@@ -82,10 +82,9 @@ const VotingPage = () => {
             if (data.type === 'TMI_VOTING_PROGRESS') {
               setProcessRate(data.data);
             } else if (data.type === 'TMI_ROUND_COMPLETED') {
-              // TMI 라운드 투표 완료 -> 투표 결과 확인 페이지로 이동
-              /* navigate(`/tmi/${roomKey}/voting`, {
+              navigate(`/tmi/${roomKey}/voteResult`, {
                 state: { roomKey },
-              }); */
+              });
             } else if (data.type === 'TMI_ALL_COMPLETED') {
               // 모든 TMI 투표 완료 -> 게임 결과 페이지로 이동
               /* navigate(`/tmi/${roomKey}/voting`, {

--- a/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
+++ b/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
@@ -75,11 +75,17 @@ const UserEnterChatRoom = () => {
     try {
       const res = await joinRoom(roomKey, { nickname, password });
       console.log(res);
-      if (res.data.data.isLeader) {
+      if (res.data.data.isLeader && useRoomUsersStore.getState().users.length === 0) {
         resetUsers();
       }
+
+      const currentUsers = useRoomUsersStore.getState().users;
+      const alreadyIn = currentUsers.some((user) => user.nickname === res.data.data.nickname);
+
       addUser(res.data.data);
-      setUser(res.data.data);
+      if (!alreadyIn) {
+        setUser(res.data.data);
+      }
       const updatedUsers = useRoomUsersStore.getState().users;
       console.log('전역 저장된 users:', updatedUsers);
       if (gameMode === 'TMI') {

--- a/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
+++ b/src/pages/userEnterChatRoom/userEnterChatRoom.tsx
@@ -45,6 +45,8 @@ const UserEnterChatRoom = () => {
 
   const { roomKey } = useParams();
   const navigate = useNavigate();
+  const prevRoomKey = useRoomUsersStore.getState().roomKey;
+  const setRoomKey = useRoomUsersStore.getState().setRoomKey;
   const addUser = useRoomUsersStore((state) => state.addUser);
   const resetUsers = useRoomUsersStore((state) => state.resetUsers);
   const setUser = useRoomUsersStore((state) => state.setUser);
@@ -75,9 +77,11 @@ const UserEnterChatRoom = () => {
     try {
       const res = await joinRoom(roomKey, { nickname, password });
       console.log(res);
-      if (res.data.data.isLeader && useRoomUsersStore.getState().users.length === 0) {
-        resetUsers();
+
+      if (res.data.data.isLeader && roomKey !== prevRoomKey) {
+        resetUsers(); // 새로운 방이면 초기화
       }
+      setRoomKey(roomKey); // 무조건 현재 roomKey로 갱신
 
       const currentUsers = useRoomUsersStore.getState().users;
       const alreadyIn = currentUsers.some((user) => user.nickname === res.data.data.nickname);

--- a/src/pages/voteResult/voteResultPage.tsx
+++ b/src/pages/voteResult/voteResultPage.tsx
@@ -44,7 +44,7 @@ const VoteResult = () => {
       try {
         const data = await getTmiVoteResult(roomKey);
         console.log(data);
-        setIsCorrect(data.isCorrect);
+        setIsCorrect(false);
         setTmiMessage(data.tmiContent);
         setMyVote(data.myVote);
         setCorrectAnswer(data.correctAnswer);
@@ -116,7 +116,12 @@ const VoteResult = () => {
       <Button onClick={() => {}} text='다음으로' />
       {isOpen && (
         <ModalPortal>
-          <SummaryModal onClose={handleCloseModal} />
+          <SummaryModal
+            correctAnswer={correctAnswer}
+            tmiContent={tmiMessage}
+            character={votedUser?.character ?? 'rabbit'}
+            onClose={handleCloseModal}
+          />
         </ModalPortal>
       )}
     </Container>

--- a/src/pages/voteResult/voteResultPage.tsx
+++ b/src/pages/voteResult/voteResultPage.tsx
@@ -43,8 +43,7 @@ const VoteResult = () => {
     (async () => {
       try {
         const data = await getTmiVoteResult(roomKey);
-        console.log(data);
-        setIsCorrect(false);
+        setIsCorrect(data.isCorrect);
         setTmiMessage(data.tmiContent);
         setMyVote(data.myVote);
         setCorrectAnswer(data.correctAnswer);
@@ -62,16 +61,18 @@ const VoteResult = () => {
   const users = useRoomUsersStore((state) => state.users);
   const votedUser = users.find((user) => user.nickname === myVote);
   const rawChar = votedUser?.character ?? 'rabbit';
-  const key = rawChar as CharacterKey;
+  const key = rawChar.toUpperCase() as CharacterKey;
   const characterImg = CharacterMap[key];
+  const correctUser = users.find((user) => user.nickname === correctAnswer);
+
   return (
     <Container>
       <VoteResultHeader>
         <ResultText> {isCorrect ? 'TMI 맞추기 성공!' : 'TMI 맞추기 실패!'}</ResultText>
         <SubTitle>
           {isCorrect
-            ? `${correctAnswer} 님은 TMI의 주인이 맞습니다.`
-            : `${correctAnswer} 님이 TMI의 주인이었습니다.`}
+            ? `${myVote} 님은 TMI의 주인이 맞습니다.`
+            : `${myVote} 님은 TMI의 주인이 아닙니다.`}
         </SubTitle>
       </VoteResultHeader>
       <VoteCandidateContainer>
@@ -103,14 +104,14 @@ const VoteResult = () => {
         </MyVoteContainer>
         <Result>
           <VoteText>투표 결과</VoteText>
-          <VoteSubContainer>
+          <ResultSubContainer>
             {voteCounts.map(({ nickname, count }) => (
               <VotenameContainer key={nickname}>
                 <SubTitle>{nickname}</SubTitle>
                 <SubTitle>{count}표</SubTitle>
               </VotenameContainer>
             ))}
-          </VoteSubContainer>
+          </ResultSubContainer>
         </Result>
       </ResultContainer>
       <Button onClick={() => {}} text='다음으로' />
@@ -119,7 +120,7 @@ const VoteResult = () => {
           <SummaryModal
             correctAnswer={correctAnswer}
             tmiContent={tmiMessage}
-            character={votedUser?.character ?? 'rabbit'}
+            character={correctUser?.character ?? 'bear'}
             onClose={handleCloseModal}
           />
         </ModalPortal>
@@ -176,6 +177,7 @@ const StampImage = styled.img`
 
 const CandidateTMI = styled(SubTitle)`
   width: 100%;
+  height: 80px;
   padding: 19px 24px;
   border-radius: 12px;
 
@@ -238,6 +240,12 @@ const VoteText = styled(SubTitle)`
 `;
 const VoteSubContainer = styled(Header)`
   gap: 14px;
+`;
+
+const ResultSubContainer = styled(VoteSubContainer)`
+  height: 50px;
+  flex-wrap: wrap;
+  overflow-y: auto;
 `;
 const VotenameContainer = styled(Header)`
   flex-direction: row;

--- a/src/pages/voteResult/voteResultPage.tsx
+++ b/src/pages/voteResult/voteResultPage.tsx
@@ -11,7 +11,7 @@ import FailStamp from '@assets/voteResult/fail_stamp.png';
 import { keyframes } from '@emotion/react';
 
 import { getTmiVoteResult } from '@api/voteResult';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import useRoomUsersStore from '@store/useRoomUsersStore';
 import { CharacterMap, CharacterKey } from '@components/shared/CharacterMap';
 
@@ -28,6 +28,8 @@ const VoteResult = () => {
   const [myVote, setMyVote] = useState('');
   const [correctAnswer, setCorrectAnswer] = useState('');
   const [voteCounts, setVoteCounts] = useState<VoteCount[]>([]);
+  const [round, setRound] = useState<number>(0);
+  const navigate = useNavigate();
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const handleOpenModal = () => {
@@ -47,6 +49,7 @@ const VoteResult = () => {
         setTmiMessage(data.tmiContent);
         setMyVote(data.myVote);
         setCorrectAnswer(data.correctAnswer);
+        setRound(data.round);
 
         const counts = Object.entries(data.votingResults)
           .map(([nickname, count]) => ({ nickname, count }))
@@ -64,6 +67,14 @@ const VoteResult = () => {
   const key = rawChar.toUpperCase() as CharacterKey;
   const characterImg = CharacterMap[key];
   const correctUser = users.find((user) => user.nickname === correctAnswer);
+
+  const handleNext = () => {
+    if (round === users.length - 1) {
+      navigate(`tmi/${roomKey}/result`);
+    } else {
+      navigate(`/tmi/${roomKey}/vote`);
+    }
+  };
 
   return (
     <Container>
@@ -114,7 +125,7 @@ const VoteResult = () => {
           </ResultSubContainer>
         </Result>
       </ResultContainer>
-      <Button onClick={() => {}} text='다음으로' />
+      <Button onClick={handleNext} text='다음으로' />
       {isOpen && (
         <ModalPortal>
           <SummaryModal

--- a/src/pages/voteResult/voteResultPage.tsx
+++ b/src/pages/voteResult/voteResultPage.tsx
@@ -12,6 +12,8 @@ import { keyframes } from '@emotion/react';
 
 import { getTmiVoteResult } from '@api/voteResult';
 import { useParams } from 'react-router-dom';
+import useRoomUsersStore from '@store/useRoomUsersStore';
+import { CharacterMap, CharacterKey } from '@components/shared/CharacterMap';
 
 interface VoteCount {
   nickname: string;
@@ -40,15 +42,14 @@ const VoteResult = () => {
 
     (async () => {
       try {
-        const d = await getTmiVoteResult(roomKey);
-        console.log(d);
-        setIsCorrect(d.isCorrect);
-        setTmiMessage(d.tmiContent);
-        setMyVote(d.myVote);
-        setCorrectAnswer(d.correctAnswer);
+        const data = await getTmiVoteResult(roomKey);
+        console.log(data);
+        setIsCorrect(data.isCorrect);
+        setTmiMessage(data.tmiContent);
+        setMyVote(data.myVote);
+        setCorrectAnswer(data.correctAnswer);
 
-        // Object → Array & 득표수 내림차순
-        const counts = Object.entries(d.votingResults)
+        const counts = Object.entries(data.votingResults)
           .map(([nickname, count]) => ({ nickname, count }))
           .sort((a, b) => b.count - a.count);
         setVoteCounts(counts);
@@ -58,6 +59,11 @@ const VoteResult = () => {
     })();
   }, [roomKey]);
 
+  const users = useRoomUsersStore((state) => state.users);
+  const votedUser = users.find((user) => user.nickname === myVote);
+  const rawChar = votedUser?.character ?? 'rabbit';
+  const key = rawChar as CharacterKey;
+  const characterImg = CharacterMap[key];
   return (
     <Container>
       <VoteResultHeader>
@@ -69,7 +75,7 @@ const VoteResult = () => {
         </SubTitle>
       </VoteResultHeader>
       <VoteCandidateContainer>
-        <CandidateCharacter />
+        <CandidateCharacter src={characterImg} />
         <StampWrapper>
           {isCorrect ? (
             <StampImage src={SuccessStamp} alt='성공 스탬프' />

--- a/src/store/useRoomUsersStore.ts
+++ b/src/store/useRoomUsersStore.ts
@@ -10,6 +10,8 @@ export interface UserInfo {
 interface RoomUsersState {
   user: UserInfo | null;
   users: UserInfo[];
+  roomKey: string;
+  setRoomKey: (key: string) => void;
   addUser: (user: UserInfo) => void;
   removeUser: (nickname: string) => void;
   resetUsers: () => void;
@@ -21,6 +23,8 @@ const useRoomUsersStore = create<RoomUsersState>()(
     (set) => ({
       users: [],
       user: null,
+      roomKey: '',
+      setRoomKey: (key) => set({ roomKey: key }),
       addUser: (user) =>
         set((state) => {
           const alreadyExists = state.users.some((u) => u.nickname === user.nickname);
@@ -33,7 +37,7 @@ const useRoomUsersStore = create<RoomUsersState>()(
         })),
       resetUsers: () => {
         set({ users: [] });
-        localStorage.removeItem('room-users');
+        localStorage.clear();
       },
       setUser: (user) => set({ user }), // 단일 유저 설정
     }),


### PR DESCRIPTION
투표 결과 페이지 api 구현


### 변경사항 🛠

- 투표 결과 페이지api 구현
- 나의 투표, tmi 정답자에 따른 캐릭터 이미지 맵핑
- 재입장 시 조건에 따라 전역 상태 초기화 또는 유지 처리 추가
- round에 따른 조건부 페이지 이동 핸들러 구현

### 특이사항 📌

- tmi 제출할 때 본인이 작성한 tmi 전역으로 저장해주실 수 있는지
- 지금 투표할 때 창 하나에서 여러명 로그인 하고 투표를 진행해야 하는데, 수정은 불가능한가요?
